### PR TITLE
updated-documentation(common-text-attributes)

### DIFF
--- a/text-common.ftd
+++ b/text-common.ftd
@@ -10,7 +10,7 @@ id: outer
 
 These attributes are available to all `ftd` "kernel" components.
 
--- ft.h1: `text-align:`
+-- ft.h1: `text-align: string`
 
 -- ft.markdown:
 
@@ -52,3 +52,112 @@ width: 400
 text-align: left
 color: $fpm.color.main.text-strong
 
+-- container: outer
+
+-- ft.h1: `style: string`
+
+-- ft.markdown:
+
+This `style` property takes input like this:
+
+-- ft.code: specifying style
+lang: ftd
+
+\-- ftd.text: FifthTry
+style: underline
+
+-- ft.markdown:
+
+This will render like this:
+
+-- ft.output:
+
+-- ftd.text: FifthTry
+style: underline
+color: $fpm.color.main.text-strong
+
+-- container: outer
+
+-- ft.code: specifying style
+lang: ftd
+
+\-- ftd.text: FifthTry
+style: strike
+
+-- ft.markdown:
+
+This will render like this:
+
+-- ft.output:
+
+-- ftd.text: FifthTry
+style: strike
+color: $fpm.color.main.text-strong
+
+-- container: outer
+
+-- ft.h1: `line-clamp:`
+
+-- ft.markdown:
+
+This `line-clamp` property takes input like this:
+
+-- ft.code: specifying line-clamp
+lang: ftd
+
+\-- ftd.column card:
+body text:
+width: 300
+min-height: 300
+boolean read_more: true
+integer max_lines:
+
+\--- ftd.text: $text
+line-clamp if $read_more: $max_lines
+
+
+\--- ftd.text: Read More
+$on-click$: toggle $read_more
+if: $read_more
+
+\--- ftd.text: Read Less
+$on-click$: toggle $read_more
+if: not $read_more
+
+
+\-- card:
+max_lines: 1
+
+this is amplepr asd askfjkjsdfkjasdjkasd asdjaskdjaksjd kajsd kasjd askjdkasjd kasjd kasjd kasjdkasjd kasjd
+
+-- ft.markdown:
+
+This will render like this:
+
+-- ft.output:
+
+-- ftd.column card:
+body text:
+width: 300
+min-height: 300
+boolean read_more: true
+integer max_lines:
+color: $fpm.color.main.text-strong
+
+--- ftd.text: $text
+line-clamp if $read_more: $max_lines
+
+
+--- ftd.text: Read More
+$on-click$: toggle $read_more
+if: $read_more
+
+--- ftd.text: Read Less
+$on-click$: toggle $read_more
+if: not $read_more
+
+
+-- card:
+max_lines: 1
+
+this is amplepr asd askfjkjsdfkjasdjkasd asdjaskdjaksjd kajsd kasjd askjdkasjd kasjd kasjd kasjdkasjd kasjd

--- a/text-common.ftd
+++ b/text-common.ftd
@@ -1,3 +1,54 @@
+-- import: fpm
+
+
 -- ft.page: Common Text Attributes
 
+-- ftd.column:
+id: outer
+
+-- ft.markdown:
+
+These attributes are available to all `ftd` "kernel" components.
+
+-- ft.h1: `text-align:`
+
+-- ft.markdown:
+
+This `text-align` property sets the alignment of text. It takes input like this:
+
+-- ft.code: specifying alignment of text
+lang: ftd
+
+\-- ftd.text: FifthTry
+text-align: center
+
+-- ft.markdown:
+
+This will render like this:
+
+-- ft.output:
+
+-- ftd.text: FifthTry
+width: 400
+text-align: center
+color: $fpm.color.main.text-strong
+
+-- container: outer
+
+-- ft.code: specifying alignment of text
+lang: ftd
+
+\-- ftd.text: FifthTry
+text-align: left
+
+-- ft.markdown:
+
+This will render like this:
+
+-- ft.output:
+
+-- ftd.text: FifthTry
+width: 400
+text-align: left
+color: $fpm.color.main.text-strong
 


### PR DESCRIPTION
updated documentation on common text attributes
![common-text-attributes-before](https://user-images.githubusercontent.com/102805262/171132852-725fd60f-d0e8-4b50-b39a-0df718f6b1ae.png)
![common-text-attributes1-now](https://user-images.githubusercontent.com/102805262/171132839-c185c799-a749-4d66-b882-404b75e09516.png)
![common-text-attributes2-now](https://user-images.githubusercontent.com/102805262/171132849-91ab6691-0e9e-4ef9-864d-52046f24a92b.png)
![common-text-attributes3-now](https://user-images.githubusercontent.com/102805262/171563594-519ef52a-0d80-4eb2-ae13-61f9e616ed74.png)
![common-text-attributes4-now](https://user-images.githubusercontent.com/102805262/171563596-f490ad7e-66f6-43b9-bab1-6cbc19485545.png)
![common-text-attributes5-now](https://user-images.githubusercontent.com/102805262/171563601-1b61e5ba-f9e5-40ca-8464-44ac3fb97858.png)
