### PR TITLE
Fixing issue of code block heading not readable

### DIFF
--- a/event-handling.ftd
+++ b/event-handling.ftd
@@ -17,11 +17,16 @@ width: fill
 margin-bottom: 20
 background-color: $fpm.color.main.background.step-2
 
---- ftd.text: the heading (click to toggle)
+--- ftd.text: The heading (click to toggle)
 $on-click$: toggle $open
+color: $fpm.color.main.text
+role: $fpm.type.copy-tight
 
 --- ftd.text:
 if: $open
+color: $fpm.color.main.text
+role: $fpm.type.copy-tight
+margin-top: $fpm.space.space-2
 
 This is some **markdown text**.
 
@@ -49,9 +54,14 @@ margin-bottom: 20
 
 \--- ftd.text: the heading (click to toggle)
 $on-click$: toggle $open
+color: $fpm.color.main.text
+role: $fpm.type.copy-tight
 
 \--- ftd.text:
 if: $open
+color: $fpm.color.main.text
+role: $fpm.type.copy-tight
+margin-top: $fpm.space.space-2
 
 This is some **markdown text**.
 


### PR DESCRIPTION
on live https://ftd.dev/event-handling/ heading of event handling example of code block example isn’t readable due to not assigned color Or font to it.
It was raised by @amitu and we fixed it with this PR.

Old before fix:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/68585007/188773376-49c1358d-2f68-4ddc-92f6-c241a6b7a883.png">

After fix:

<img width="762" alt="image" src="https://user-images.githubusercontent.com/68585007/188773454-d0e5674c-5a0d-44ad-b21d-330781fe5fe4.png">
